### PR TITLE
feat: add postcode search to streetworks map

### DIFF
--- a/src/components/Design/MinorAlert.tsx
+++ b/src/components/Design/MinorAlert.tsx
@@ -5,7 +5,7 @@ import Colors from '@data/colors.json'
 import { makeStyles } from '@material-ui/core'
 import clsx from 'clsx'
 
-export interface IMinorAlertProps {
+export interface IMinorAlertProps extends React.HTMLProps<HTMLDivElement> {
   className?: string
   heading?: React.ReactNode
   children: React.ReactNode

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -33,6 +33,9 @@ const useStyles = makeStyles({
       transform: 'rotate(1turn)',
     },
   },
+  block: {
+    display: 'block',
+  },
 })
 
 interface IProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -48,7 +51,7 @@ export default function LoadingSpinner({ inline, style, size, className, ...prop
     <Tag
       role="status"
       aria-label="Loading spinner"
-      className={clsx(classes.root, className)}
+      className={clsx(classes.root, className, { [classes.block]: !inline })}
       style={
         {
           '--size': typeof size === 'number' ? `${size}px` : size,

--- a/src/components/Maps/PostcodeSearch.tsx
+++ b/src/components/Maps/PostcodeSearch.tsx
@@ -59,7 +59,7 @@ export default function PostcodeSearch({ map }: PostcodeSearchProps) {
         setPostcodeInput(json.result.postcode)
 
         if (map) {
-          map.setView([json.result.latitude, json.result.longitude], 14, {
+          map.setView([json.result.latitude, json.result.longitude], 15, {
             animate: true,
           })
         } else {

--- a/src/components/Maps/PostcodeSearch.tsx
+++ b/src/components/Maps/PostcodeSearch.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react'
+
+import Section from '@components/Design/Section'
+import TextBox from '@components/Inputs/TextBox'
+import LoadingSpinner from '@components/LoadingSpinner'
+import Button from '@components/Inputs/Button'
+
+import type { Map } from 'leaflet'
+import MinorAlert from '@components/Design/MinorAlert'
+import { makeStyles } from '@material-ui/core'
+import useIsFirstRender from '@hooks/useIsFirstRender'
+
+export interface PostcodeSearchProps {
+  map: Map | null
+}
+
+const useStyles = makeStyles({
+  input: {
+    display: 'block',
+    maxWidth: 300,
+  },
+  button: {
+    marginTop: 16,
+  },
+  error: {
+    marginTop: 16,
+  },
+})
+
+export default function PostcodeSearch({ map }: PostcodeSearchProps) {
+  const classes = useStyles()
+  const [postcodeInput, setPostcodeInput] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSearch() {
+    setLoading(true)
+    setError(null)
+
+    const response = await fetch(`https://api.postcodes.io/postcodes/${encodeURIComponent(postcodeInput)}`)
+
+    if (!response.ok) {
+      // Error
+      try {
+        const json = await response.json()
+
+        if ('error' in json && typeof json.error === 'string') {
+          setError(json.error)
+        } else {
+          setError('An unknown error occurred while looking up this postcode. Please get in touch if you keep seeing this.')
+        }
+      } catch (ex) {
+        setError('An unknown error occurred while looking up this postcode. Please get in touch if you keep seeing this.')
+      }
+    } else {
+      try {
+        const json = await response.json()
+
+        setPostcodeInput(json.result.postcode)
+
+        if (map) {
+          map.setView([json.result.latitude, json.result.longitude], 14, {
+            animate: true,
+          })
+        } else {
+          setError('An error occurred while looking up this postcode: invalid map instance.')
+        }
+      } catch (ex) {
+        setError('An unknown error occurred while looking up this postcode. Please get in touch if you keep seeing this.')
+      }
+    }
+
+    setLoading(false)
+  }
+
+  return (
+    <Section>
+      <TextBox
+        label="Jump to postcode"
+        helpText="Search for any UK postcode to centre the map on it"
+        className={classes.input}
+        onInput={val => setPostcodeInput(val)}
+        value={postcodeInput}
+        placeholder="SW1A 1AA"
+        disabled={loading}
+        endAdornment={!loading ? undefined : <LoadingSpinner size="1.25em" />}
+        onKeyDown={e => {
+          if (e.key === 'Enter') {
+            handleSearch()
+          }
+        }}
+      />
+
+      {error && (
+        <MinorAlert role="status" aria-live="assertive" color="primaryRed" coloredBackground heading="Error" className={classes.error}>
+          {error}
+        </MinorAlert>
+      )}
+
+      <Button className={classes.button} aria-live="polite" disabled={loading} onClick={handleSearch}>
+        {loading ? 'Searching...' : 'Search'}
+      </Button>
+    </Section>
+  )
+}

--- a/src/components/Maps/StreetworksMap/PromoterSettingsDialog.tsx
+++ b/src/components/Maps/StreetworksMap/PromoterSettingsDialog.tsx
@@ -1,6 +1,9 @@
-import React, { useState } from 'react'
-import Checkbox from '@components/Inputs/Checkbox'
+import React, { useState, useCallback } from 'react'
+
 import { ModalDialog, ModalDialogContent, ModalDialogHeaderAndTitle } from '@components/ModalDialog'
+import Checkbox from '@components/Inputs/Checkbox'
+import ButtonLink from '@components/Links/ButtonLink'
+
 import {
   getPromoterStates,
   IOneNetworkStreetworksPromoter,
@@ -8,13 +11,10 @@ import {
   setPromoterState,
   setAllPromotersState,
 } from '@functions/maps/streetworks/streetworksPromoterUtils'
+import Breakpoints from '@data/breakpoints'
 
 import { makeStyles } from '@material-ui/core'
-
 import clsx from 'clsx'
-import ButtonLink from '@components/Links/ButtonLink'
-import Breakpoints from '@data/breakpoints'
-import { useCallback } from 'react'
 
 const useStyles = makeStyles({
   categoryHeader: {

--- a/src/components/Maps/StreetworksMap/StreetworksMap.tsx
+++ b/src/components/Maps/StreetworksMap/StreetworksMap.tsx
@@ -1,11 +1,22 @@
 import React, { useCallback, useState } from 'react'
 
+import { PromoterSettingsDialog } from './PromoterSettingsDialog'
+import { BaseMapSetup } from './BaseMapSetup'
+import { StreetworksMarkers } from './StreetworksMarkers'
+import ButtonLink from '@components/Links/ButtonLink'
+import Section from '@components/Design/Section'
+import { MapStatusMessages } from './MapStatusMessages'
+
 import useFixLeafletAssets from '@hooks/useFixLeafletAssets'
 import { useUserLocation } from '@hooks/useUserLocation'
 import useForceRender from '@hooks/useForceRerender'
 import { useErrorBoundary } from 'react-use-error-boundary'
 
 import { MapContainer, ScaleControl, useMap, useMapEvent } from 'react-leaflet'
+import { GeolocationMarker } from '@leaflet/GeolocationMarker'
+import GeolocationButton from '@leaflet/GeolocationButton'
+import MapCustomButtonsContainer from '@leaflet/MapCustomButtonsContainer'
+import MapCustomButton from '@leaflet/MapCustomButton'
 
 import dayjs from 'dayjs'
 import dayjs_tz from 'dayjs/plugin/timezone'
@@ -14,20 +25,10 @@ import dayjs_utc from 'dayjs/plugin/utc'
 dayjs.extend(dayjs_tz)
 dayjs.extend(dayjs_utc)
 
+import type { Map } from 'leaflet'
+
 import 'leaflet/dist/leaflet.css'
 import './StreetworksMap.less'
-
-import { GeolocationMarker } from '@leaflet/GeolocationMarker'
-import GeolocationButton from '@leaflet/GeolocationButton'
-
-import { PromoterSettingsDialog } from './PromoterSettingsDialog'
-import { BaseMapSetup } from './BaseMapSetup'
-import { StreetworksMarkers } from './StreetworksMarkers'
-import ButtonLink from '@components/Links/ButtonLink'
-import Section from '@components/Design/Section'
-import { MapStatusMessages } from './MapStatusMessages'
-import MapCustomButtonsContainer from '@leaflet/MapCustomButtonsContainer'
-import MapCustomButton from '@leaflet/MapCustomButton'
 
 export interface IStreetworksSitePoint {
   locationId: number
@@ -41,7 +42,7 @@ export interface IStreetworksMapProps {
   sites: React.ReactNode
 }
 
-export default function StreetworksMap() {
+const StreetworksMap = React.forwardRef<Map>(function StreetworksMap(props, ref) {
   useFixLeafletAssets()
 
   const [error] = useErrorBoundary()
@@ -71,6 +72,7 @@ export default function StreetworksMap() {
       center={[51.505, -0.09]}
       zoom={13}
       attributionControl={false}
+      ref={ref}
     >
       <GeolocationMarker />
       <CustomControlButtons />
@@ -83,7 +85,9 @@ export default function StreetworksMap() {
       <MapStatusMessages />
     </MapContainer>
   )
-}
+})
+
+export default StreetworksMap
 
 function CustomControlButtons() {
   const L = window.L as typeof import('leaflet')

--- a/src/components/Maps/TubeDasMap/tube-tunnel-feeder-figure.inline.svg
+++ b/src/components/Maps/TubeDasMap/tube-tunnel-feeder-figure.inline.svg
@@ -1,14 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 264.583 34.953">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 264.58 34.95">
   <title>Drawing of two tube stations (A, B) with tunnels between, showing leaky feeders starting at the middle of each station, spanning out the tunnels either end of each station before meeting in the middle with a small gap.</title>
-  <path fill="gray" d="M92.605 14.063h79.374v10.583H92.605zM224.895 14.063h39.688v10.583h-39.688zM0 14.063h39.688v10.583H-.002z"/>
-  <path fill="#b3b3b3" d="M171.98 11.946h52.917v13.229H171.98zM39.688 11.946h52.916v13.229H39.689z"/>
-  <text xml:space="preserve" x="26.352" y="110.045" stroke-width=".794" font-family="Jost" font-size="7.056" style="-inkscape-font-specification:&quot;Jost&quot;;text-align:center" text-anchor="middle" transform="translate(39.688 -105)"><tspan x="26.352" y="110.045">Station A</tspan></text>
-  <text xml:space="preserve" x="158.743" y="110.045" stroke-width=".794" font-family="Jost" font-size="7.056" style="-inkscape-font-specification:&quot;Jost&quot;;text-align:center" text-anchor="middle" transform="translate(39.688 -105)"><tspan x="158.743" y="110.045">Station B</tspan></text>
-  <path stroke="#c55252" stroke-width=".945" d="M.646 27.766h131"/>
-  <path stroke="#c55252" stroke-width=".83" d="M66.146 7.448v20.026"/>
-  <path stroke="#55f" stroke-width=".945" d="M132.938 27.766h131"/>
-  <path stroke="#55f" stroke-width=".83" d="M198.438 7.448v20.026"/>
-  <text xml:space="preserve" x="92.59" y="116.487" stroke-width=".794" font-family="Jost" font-size="5.644" style="-inkscape-font-specification:&quot;Jost&quot;;text-align:center" text-anchor="middle" transform="translate(39.688 -105)"><tspan x="92.59" y="116.487">tunnel</tspan></text>
-  <text xml:space="preserve" x="26.437" y="139.157" stroke-width=".794" font-family="Jost" font-size="4.939" style="-inkscape-font-specification:&quot;Jost&quot;;text-align:center" text-anchor="middle" transform="translate(39.688 -105)"><tspan x="26.437" y="139.157">Station A-fed leaky feeders</tspan></text>
-  <text xml:space="preserve" x="158.729" y="139.061" stroke-width=".794" font-family="Jost" font-size="4.939" style="-inkscape-font-specification:&quot;Jost&quot;;text-align:center" text-anchor="middle" transform="translate(39.688 -105)"><tspan x="158.729" y="139.061">Station B-fed leaky feeders</tspan></text>
+  <path fill="gray" d="M92.6 14.06h79.38v10.59H92.6zm132.3 0h39.68v10.59H224.9zM0 14.06h39.69v10.59H-.01z"/>
+  <path fill="#b3b3b3" d="M171.98 11.95h52.92v13.22h-52.92zm-132.3 0H92.6v13.22H39.7z"/>
+  <text xml:space="preserve" x="26.35" y="110.05" stroke-width=".79" font-family="Jost" font-size="7.06" text-anchor="middle" transform="translate(39.69 -105)"><tspan x="26.35" y="110.05">Station A</tspan></text>
+  <text xml:space="preserve" x="158.74" y="110.05" stroke-width=".79" font-family="Jost" font-size="7.06" text-anchor="middle" transform="translate(39.69 -105)"><tspan x="158.74" y="110.05">Station B</tspan></text>
+  <path stroke="#c55252" stroke-width=".94" d="M.65 27.77h131"/>
+  <path stroke="#c55252" stroke-width=".83" d="M66.15 7.45v20.02"/>
+  <path stroke="#55f" stroke-width=".94" d="M132.94 27.77h131"/>
+  <path stroke="#55f" stroke-width=".83" d="M198.44 7.45v20.02"/>
+  <g stroke-width=".79" font-family="Jost" text-anchor="middle">
+    <text xml:space="preserve" x="92.59" y="116.49" font-size="5.64" transform="translate(39.69 -105)"><tspan x="92.59" y="116.49">tunnel</tspan></text>
+    <text xml:space="preserve" x="26.44" y="139.16" font-size="4.94" transform="translate(39.69 -105)"><tspan x="26.44" y="139.16">Station A-fed leaky feeders</tspan></text>
+    <text xml:space="preserve" x="158.73" y="139.06" font-size="4.94" transform="translate(39.69 -105)"><tspan x="158.73" y="139.06">Station B-fed leaky feeders</tspan></text>
+  </g>
 </svg>

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -41,7 +41,10 @@ const SEO: React.FC<Props> = ({ description, meta, title }) => {
       <Meta name="twitter:card" content="summary" />
       <Meta name="twitter:title" content={title} />
       <Meta name="twitter:description" content={metaDescription} />
-      <Meta name="twitter:creator" content="@davwheat" />
+      <Meta name="twitter:creator" content="@davwheat_" />
+      <Meta name="twitter:creator:id" content="1033075771659747329" />
+      <Meta name="twitter:site" content="@davwheat_" />
+      <Meta name="twitter:site:id" content="1033075771659747329" />
 
       {meta && meta.map((m, i) => <Meta key={`${m.name}--${i}`} name={m.name} content={m.content} />)}
     </>

--- a/src/functions/maps/streetworks/streetworksPromoterUtils.ts
+++ b/src/functions/maps/streetworks/streetworksPromoterUtils.ts
@@ -915,13 +915,7 @@ export const promoterAliases: Record<string, string[]> = AllStreetworksPromoters
   {} as Record<string, string[]>,
 )
 
-export const promoterIcons: Record<string, L.DivIcon> = AllStreetworksPromoters.reduce(
-  (acc, promoter) => {
-    acc[promoter.id] = createPromoterIcon(promoter.icon.text, promoter.icon.type)!
-    return acc
-  },
-  {} as Record<string, L.DivIcon>,
-)
+export let promoterIcons: Record<string, L.DivIcon> = {}
 
 export const promoterNames: Record<string, string> = AllStreetworksPromoters.reduce(
   (acc, promoter) => {
@@ -937,7 +931,7 @@ function createPromoterIcon(
 ): L.DivIcon | null {
   // Mess is to fix Gatsby SSR issues, as this function is called
   // during the build process
-  if (typeof window === 'undefined') return null
+  if (typeof window === 'undefined' || typeof window.L === 'undefined') return null
 
   const L = window.L as typeof import('leaflet')
 
@@ -979,6 +973,16 @@ export function isPromoterDataPoint(dataPoint: StreetworksDataPoint) {
 
 export function getPromoterStates(): Record<string, boolean> {
   const promoterIdsByCategory: Record<string, string[]> = {}
+
+  if (Object.keys(promoterIcons).length === 0) {
+    promoterIcons = AllStreetworksPromoters.reduce(
+      (acc, promoter) => {
+        acc[promoter.id] = createPromoterIcon(promoter.icon.text, promoter.icon.type)!
+        return acc
+      },
+      {} as Record<string, L.DivIcon>,
+    )
+  }
 
   AllStreetworksPromoters.forEach(promoter => {
     promoterIdsByCategory[promoter.category] ||= []

--- a/src/pages/gb/london-underground-connectivity.tsx
+++ b/src/pages/gb/london-underground-connectivity.tsx
@@ -194,16 +194,7 @@ export default function TubeConnectivityMap({ location }: PageProps) {
         </Section>
 
         <Section width="full" className={classes.mapSection}>
-          <NoSsr
-            fallback={
-              <div className={classes.loading}>
-                <LoadingSpinner />
-                <p className="text-speak">Loading map...</p>
-              </div>
-            }
-          >
-            <TubeDasMap hideSectionsWithNoConnectivity={mapOptions.hideUnconnectedSegments} hiddenLines={mapOptions.hiddenLines} />
-          </NoSsr>
+          <TubeDasMap hideSectionsWithNoConnectivity={mapOptions.hideUnconnectedSegments} hiddenLines={mapOptions.hiddenLines} />
         </Section>
 
         <TubeDeploymentInfo />

--- a/src/pages/maps/streetworks.tsx
+++ b/src/pages/maps/streetworks.tsx
@@ -68,9 +68,7 @@ export default function StreetworksMapPage({ location }: PageProps) {
         {/* <StreetworksMapSettings /> */}
 
         <Section width="full" className={classes.mapSection}>
-          <NoSsr>
-            <StreetworksMap />
-          </NoSsr>
+          <StreetworksMap />
         </Section>
       </ErrorBoundaryContext>
     </Layout>

--- a/src/pages/maps/streetworks.tsx
+++ b/src/pages/maps/streetworks.tsx
@@ -1,11 +1,13 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import Layout from '@components/Layout'
 import Hero from '@components/Design/Hero'
 import Breadcrumbs from '@components/Design/Breadcrumbs'
 import Section from '@components/Design/Section'
 import StreetworksMap from '@components/Maps/StreetworksMap/StreetworksMap'
-import { StreetworksMapSettings } from '@components/Maps/StreetworksMap/StreetworksMapSettings'
+import PostcodeSearch from '@components/Maps/PostcodeSearch'
+import LoadingSpinner from '@components/LoadingSpinner'
+// import { StreetworksMapSettings } from '@components/Maps/StreetworksMap/StreetworksMapSettings'
 
 import Colors from '@data/colors.json'
 
@@ -13,6 +15,8 @@ import { makeStyles, NoSsr } from '@material-ui/core'
 import { ErrorBoundaryContext } from 'react-use-error-boundary'
 
 import type { PageProps } from 'gatsby'
+import type { Map } from 'leaflet'
+import TextBox from '@components/Inputs/TextBox'
 
 const useStyles = makeStyles({
   mapSection: {
@@ -32,6 +36,7 @@ const useStyles = makeStyles({
 
 export default function StreetworksMapPage({ location }: PageProps) {
   const classes = useStyles()
+  const [map, setMap] = useState<Map | null>(null)
 
   return (
     <Layout
@@ -56,19 +61,37 @@ export default function StreetworksMapPage({ location }: PageProps) {
         />
 
         <Section>
-          <h2 className="text-loud">About</h2>
+          <h2 className="text-loud">What are streetworks?</h2>
           <p className="text-speak">
-            View a map of current and future registered streetworks relating to telecoms infrastructure in Great Britain.
+            Streetworks are the name for any form of construction works taking place on or near a carriageway or footway. When these works take
+            place, companies must apply to the local authority responsible for the road for permission to conduct their works.
           </p>
           <p className="text-speak">
-            You can also filter whose works to show by opening the settings modal with the cog in the bottom-right of the&nbsp;map.
+            Obtaining this permission ensures that correct traffic management systems are in place, such as temporary traffic lights, lane
+            closures or diversions, as well as ensuring that multiple planned works don't interfere with each other, or potential large-scale
+            events.
+          </p>
+
+          <h2 className="text-loud">Our map</h2>
+          <p className="text-speak">
+            We've put together a wonderful map that will show you all telecommunication-related works taking place across Great Britain. Our data
+            comes from the same place as BIDB.uk (the Better Internet Dashboard), so you know you can trust it.
+          </p>
+          <p className="text-speak">
+            On our site, most companies (known as streetworks promoters) have their own custom code (up to 4 letters), as well as an appropriate
+            brand colour to match. If you spot one we haven't got, let us know on Twitter.
+          </p>
+          <p className="text-speak">
+            You can tap a map bubble to show detailed information about the works. Where possible, we try to provide descriptions of the work
+            being done, but not all local authorities release this data to the public, unfortunately. You can also filter which promoters to show
+            on the map from the settings dialog with the cog in the bottom-right of the&nbsp;map.
           </p>
         </Section>
 
-        {/* <StreetworksMapSettings /> */}
+        <PostcodeSearch map={map} />
 
         <Section width="full" className={classes.mapSection}>
-          <StreetworksMap />
+          <StreetworksMap ref={m => setMap(m)} />
         </Section>
       </ErrorBoundaryContext>
     </Layout>


### PR DESCRIPTION
Primary reason for this is accessibility.

I had a message from a screenreader user who stated they couldn't use the map as they can't see what location is on screen at any one time! Bit of an oversight for me!

This PR has a reusable postcode search component that is plug-and-play with any Leaflet map to allow future integrations too.

Relates to #138 