### PR TITLE
fix: change streetworks map center coords

### DIFF
--- a/src/components/Maps/StreetworksMap/StreetworksMap.tsx
+++ b/src/components/Maps/StreetworksMap/StreetworksMap.tsx
@@ -69,7 +69,7 @@ const StreetworksMap = React.forwardRef<Map>(function StreetworksMap(props, ref)
           height: 'var(--map-height)',
         } as any
       }
-      center={[51.505, -0.09]}
+      center={[51.519, -0.63]}
       zoom={13}
       attributionControl={false}
       ref={ref}


### PR DESCRIPTION
Was centred on London and was causing a lot of lag on first load (especially on mobile devices), changed to Slough as less markers